### PR TITLE
Remove unnecessary terminology from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ a ClickPLC. For example:
 import asyncio
 from productivity import ProductivityPLC
 
-async def get():
+async def run():
     async with ProductivityPLC('the-plc-ip-address', 'path/to/tags.csv') as plc:
         print(await plc.get())
 
-asyncio.run(get())
+asyncio.run(run())
 ```
 
 It is also possible to set tag values:
 
 ```python
-async def set():
+async def run():
     async with ProductivityPLC('the-plc-ip-address', 'path/to/tags.csv') as plc:
         await plc.set(start=True, setpoint=1.1)
 
-asyncio.run(set())
+asyncio.run(run())
 ```

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ async def get():
 asyncio.run(get())
 ```
 
-It's possible to set coils and registers on the PLC as well using keyword arguments
-```python
-async def set(**kwargs):
-    async with ProductivityPLC('the-plc-ip-address', 'path/to/tags.csv') as plc:
-        print(await plc.set(**kwargs))
+It is also possible to set tag values:
 
-asyncio.run(set(target=0, setpoint=1.1))
+```python
+async def set():
+    async with ProductivityPLC('the-plc-ip-address', 'path/to/tags.csv') as plc:
+        await plc.set(start=True, setpoint=1.1)
+
+asyncio.run(set())
 ```


### PR DESCRIPTION
The goal of this repo is to abstract away modbus terminology and advanced python. I think the `set` example currently introduces both but doesn't need to.