### PR TITLE
Datatypes for integers

### DIFF
--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -22,19 +22,19 @@ from productivity.util import AsyncioModbusClient
 data_types = {
     'AIF32': 'float',  # Analog Input Float 32-bit
     'F32': 'float',    # Float 32-bit
-    'AIS32': 'int32',  # Analog Input (S)integer 32-bit
-    'AOS32': 'int32',  # Analog Output (S)integer 32-bit
-    'S32': 'int32',    # (S)integer 32-bit'
-    'C': 'bool',       # (C) Boolean,
+    'AIS32': 'int32',  # Analog Input Signed integer 32-bit
+    'AOS32': 'int32',  # Analog Output Signed integer 32-bit
+    'S32': 'int32',    # Signed integer 32-bit
+    'C': 'bool',       # (C) Boolean
     'DI': 'bool',      # Discrete Input
     'DO': 'bool',      # Discrete Output
     'SBR': 'bool',     # System Boolean Read-only
     'SBRW': 'bool',    # System Boolean Read-Write
-    'MST': 'bool',     # Module Status biT
+    'MST': 'bool',     # Module STatus bit
     'STR': 'str',      # STRing
     'SSTR': 'str',     # System STRing
-    'SWR': 'int',      # System (W)integer Read-only
-    'SWRW': 'int'      # System (W)integer Read-Write
+    'SWR': 'int',      # System Word Read-only
+    'SWRW': 'int'      # System Word Read-Write
 }
 type_start = {
     'discrete_output': 0,

--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -33,8 +33,8 @@ data_types = {
     'MST': 'bool',     # Module STatus bit
     'STR': 'str',      # STRing
     'SSTR': 'str',     # System STRing
-    'SWR': 'int',      # System Word Read-only
-    'SWRW': 'int'      # System Word Read-Write
+    'SWR': 'int16',      # System Word Read-only
+    'SWRW': 'int16'      # System Word Read-Write
 }
 type_start = {
     'discrete_output': 0,
@@ -183,7 +183,7 @@ class ProductivityPLC(AsyncioModbusClient):
                 raise ValueError(f'{value} is too long for {key}. '
                                  f'Max: {chars} chars')
             builder.add_string(value.ljust(chars))
-        elif data_type == 'int':
+        elif data_type == 'int16':
             builder.add_16bit_int(value)
         elif data_type == 'int32':
             builder.add_32bit_int(value)
@@ -255,7 +255,7 @@ class ProductivityPLC(AsyncioModbusClient):
                     # Handle odd length strings
                     current += ceil(chars / 2)
                     decoder._pointer += chars % 2
-                elif data_type == 'int':
+                elif data_type == 'int16':
                     result[tag] = decoder.decode_16bit_int()
                     current += 1
                 elif data_type == 'int32':

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='productivity',
-    version='0.3.15',
+    version='0.4.0',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The motivation for this change was running into a [bug](https://github.com/numat/controllers/blob/master/controllers/avon_breakthrough/static/ui.js#L27) where a frontend didn't properly read `int32`.

`int` is slightly ambiguous, in the productivity driver it means 16-bits, but in Python 3 `int` is unbounded.  By having the productivity driver explicitly use `int16` or `int32` hopefully this is more clear.  Note that none of the datatypes the driver currently supports are unsigned, so that can be ignored.

bump to .4 because this is technically a breaking API change.