### PR TITLE
add docstrings and don't open a mobdus client if mocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ you don't need to remember the addresses.
 
 ### Command Line
 
-To print the tags and their values, simply call the library with the PLC IP address and 
-the tags file.
+To print the tags and their values, simply call the library with the PLC IP address and the tags file.
 ```
 $ productivity the-plc-ip-address path/to/tags.csv
 ```
@@ -49,7 +48,7 @@ See `productivity --help` for more.
 ### Python
 
 This driver uses Python ≥3.5's async/await syntax to asynchronously communicate with
-a ClickPLC. For example:
+a Productivity2000 PLC. For example (note that asyncio.run() requires Python >=3.7):
 
 ```python
 import asyncio

--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -321,8 +321,8 @@ class ProductivityPLC(AsyncioModbusClient):
         tells me it's an issue.
 
         """
-        addresses = sorted([tag['address']['start'] for tag in tags.values()] +
-                           [tag['address']['end'] for tag in tags.values()])
+        addresses = sorted([tag['address']['start'] for tag in tags.values()]
+                           + [tag['address']['end'] for tag in tags.values()])
         output = {}
         do_count = 0
         for a in addresses:
@@ -349,7 +349,7 @@ class ProductivityPLC(AsyncioModbusClient):
                                  " If you need more, open a github issue at "
                                  "numat/productivity.")
 
-        if 'discrete_output' in output and do_count/2 < output['discrete_output']['count']:
+        if 'discrete_output' in output and do_count / 2 < output['discrete_output']['count']:
             self.discontinuous_discrete_output = True
             logging.warning(
                 "Warning: Your tags file has gaps in discrete output modbus addresses."

--- a/productivity/mock.py
+++ b/productivity/mock.py
@@ -1,3 +1,12 @@
+"""
+Python mock driver for AutomationDirect Productivity Series PLCs.
+
+Uses local storage instead of remote communications.
+
+Distributed under the GNU General Public License v2
+Copyright (C) 2020 NuMat Technologies
+"""
+
 from collections import defaultdict
 from unittest.mock import MagicMock
 
@@ -10,16 +19,21 @@ from productivity.driver import ProductivityPLC as realProductivityPLC
 
 
 class AsyncMock(MagicMock):
-    """Magic mock that works with async methods"""
+    """Magic mock that works with async methods."""
+
     async def __call__(self, *args, **kwargs):
+        """Convert __call__ into an async coroutine."""
         return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
 class ProductivityPLC(realProductivityPLC):
-    """A version of the driver with the remote communication replaced with local data storage
-    for testing"""
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    """Mock Productivity driver using local storage instead of remote communication."""
+
+    def __init__(self, address, tag_filepath, timeout=1, *args, **kwargs):
+        self.discontinuous_discrete_output = False
+        self.tags = self._load_tags(tag_filepath)
+        self.addresses = self._calculate_addresses(self.tags)
+        self.map = {data['address']['start']: tag for tag, data in self.tags.items()}
         self.client = AsyncMock()
         self._coils = defaultdict(bool)
         self._discrete_inputs = defaultdict(bool)

--- a/productivity/mock.py
+++ b/productivity/mock.py
@@ -8,7 +8,7 @@ Copyright (C) 2020 NuMat Technologies
 """
 
 from collections import defaultdict
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pymodbus.bit_read_message import ReadCoilsResponse, ReadDiscreteInputsResponse
 from pymodbus.bit_write_message import WriteSingleCoilResponse, WriteMultipleCoilsResponse
@@ -29,11 +29,9 @@ class AsyncMock(MagicMock):
 class ProductivityPLC(realProductivityPLC):
     """Mock Productivity driver using local storage instead of remote communication."""
 
+    @patch('pymodbus.client.asynchronous.asyncio.ReconnectingAsyncioModbusTcpClient')
     def __init__(self, address, tag_filepath, timeout=1, *args, **kwargs):
-        self.discontinuous_discrete_output = False
-        self.tags = self._load_tags(tag_filepath)
-        self.addresses = self._calculate_addresses(self.tags)
-        self.map = {data['address']['start']: tag for tag, data in self.tags.items()}
+        super().__init__(address, tag_filepath, timeout)
         self.client = AsyncMock()
         self._coils = defaultdict(bool)
         self._discrete_inputs = defaultdict(bool)

--- a/productivity/mock.py
+++ b/productivity/mock.py
@@ -18,12 +18,16 @@ from pymodbus.register_write_message import WriteMultipleRegistersResponse
 from productivity.driver import ProductivityPLC as realProductivityPLC
 
 
-class AsyncMock(MagicMock):
+class AsyncClientMock(MagicMock):
     """Magic mock that works with async methods."""
 
     async def __call__(self, *args, **kwargs):
-        """Convert __call__ into an async coroutine."""
-        return super(AsyncMock, self).__call__(*args, **kwargs)
+        """Convert regular mocks into into an async coroutine."""
+        return super().__call__(*args, **kwargs)
+
+    def stop(self):
+        """Overide 'stop' as it is the one non-async method in the client."""
+        pass
 
 
 class ProductivityPLC(realProductivityPLC):
@@ -32,7 +36,7 @@ class ProductivityPLC(realProductivityPLC):
     @patch('pymodbus.client.asynchronous.asyncio.ReconnectingAsyncioModbusTcpClient')
     def __init__(self, address, tag_filepath, timeout=1, *args, **kwargs):
         super().__init__(address, tag_filepath, timeout)
-        self.client = AsyncMock()
+        self.client = AsyncClientMock()
         self._coils = defaultdict(bool)
         self._discrete_inputs = defaultdict(bool)
         self._registers = defaultdict(bytes)

--- a/productivity/tests/test_driver.py
+++ b/productivity/tests/test_driver.py
@@ -1,3 +1,4 @@
+"""Test the driver correctly parses a tags file and responds with correct data."""
 import pytest
 
 from productivity.mock import ProductivityPLC
@@ -5,15 +6,18 @@ from productivity.mock import ProductivityPLC
 
 @pytest.fixture
 def plc_driver():
+    """Confirm the driver correctly initializes with a good tags file."""
     return ProductivityPLC('fake ip', 'tests/plc_tags.csv')
 
 
 def test_init():
+    """Confirm the driver detects an improper tags file."""
     with pytest.raises(TypeError, match='unsupported data type'):
         ProductivityPLC('fake ip', 'tests/bad_tags.csv')
 
 
 def test_get_tags(plc_driver):
+    """Confirm the driver returns the tags defined in the tags file."""
     expected = {
         'AV-101': {'address': {'start': 1, 'end': 1}, 'id': 'DO-0.1.3.1',
                    'comment': 'Inert valve', 'type': 'bool'},
@@ -45,6 +49,7 @@ def test_get_tags(plc_driver):
 
 @pytest.mark.asyncio
 async def test_get(plc_driver):
+    """Confirm that the driver returns correct values on get() calls."""
     expected = {'AV-101': False, 'AV-102': False, 'toggle_AV-101': False,
                 'toggle_AV-102': False, 'FALL-101_OK': False, 'FAL-101_OK': False,
                 'ESD_OK': False, 'FI-101': 0.0, 'FI-102': 0.0, 'Raw Pressure': 0,
@@ -55,6 +60,7 @@ async def test_get(plc_driver):
 
 @pytest.mark.asyncio
 async def test_roundtrip(plc_driver):
+    """Confirm various datatypes are read back correctly after being set."""
     await plc_driver.set({'AV-101': True, 'toggle_AV-101': True, 'Raw Pressure': 1,
                           'FI-101': 20.0, 'GAS-101': 'FOO'})
     expected = {'AV-101': True, 'AV-102': False, 'toggle_AV-101': True,
@@ -67,6 +73,7 @@ async def test_roundtrip(plc_driver):
 
 @pytest.mark.asyncio
 async def test_set_errors(plc_driver):
+    """Confirm the driver gives an error on invalid set() calls."""
     with pytest.raises(TypeError, match='Invalid input'):
         await plc_driver.set('FOO')
     with pytest.raises(TypeError, match='Invalid input'):
@@ -79,6 +86,7 @@ async def test_set_errors(plc_driver):
 
 @pytest.mark.asyncio
 async def test_type_checking(plc_driver):
+    """Confirm the driver responds to set() requests with correct datatypes."""
     with pytest.raises(ValueError, match='Expected AV-101 to be a bool'):
         await plc_driver.set({'AV-101': 1})
     with pytest.raises(ValueError, match='Expected toggle_AV-101 to be a bool'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,8 @@ universal = 1
 
 [flake8]
 max-complexity = 15
-max-line-length = 89
+max-line-length = 99
+docstring-convention = pep257
+
+# no docstrings in __init__.py
+ignore = D104,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ max-line-length = 99
 docstring-convention = pep257
 
 # no docstrings in __init__.py
-ignore = D104,D107
+ignore = D104,D107,W503


### PR DESCRIPTION
The original goal was to prevent the mocked driver from trying to open a MODBUS TCP/IP connection and emitting warnings when it fails to connect:
```Task was destroyed but it is pending!
task: <Task pending coro=<AsyncioModbusClient._connect() running at /home/alex/github/productivity/productivity/util.py:39>>
/usr/lib/python3.6/asyncio/base_events.py:509: RuntimeWarning: coroutine 'AsyncioModbusClient._connect' was never awaited
  self._ready.clear()
Task was destroyed but it is pending!
task: <Task pending coro=<AsyncioModbusClient._connect() running at /home/alex/github/productivity/productivity/util.py:39>>
```

I followed the strategy used [here](https://github.com/numat/controllers/commit/0dc3dd6cedaa20b29486142b830caeb43e3ceefc#diff-6a686fec55320a2cca68390e84b14e13L23), but am not sure I understood things entirely.  It shuts up the warning when running `pytest`, at least

Also added a lot of docstrings and minor readme clarifications.

