### PR TITLE
Fix writing a single register

### DIFF
--- a/productivity/mock.py
+++ b/productivity/mock.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from pymodbus.bit_read_message import ReadCoilsResponse, ReadDiscreteInputsResponse
 from pymodbus.bit_write_message import WriteSingleCoilResponse, WriteMultipleCoilsResponse
 from pymodbus.register_read_message import ReadHoldingRegistersResponse
+from pymodbus.register_write_message import WriteSingleRegisterResponse
 from pymodbus.register_write_message import WriteMultipleRegistersResponse
 
 from productivity.driver import ProductivityPLC as realProductivityPLC
@@ -63,6 +64,10 @@ class ProductivityPLC(realProductivityPLC):
             for i, d in enumerate(data):
                 self._coils[address + i] = d
             return WriteMultipleCoilsResponse(address, len(data))
+        elif method == 'write_register':
+            address, data = args
+            self._registers[address] = data
+            return WriteSingleRegisterResponse(address, data)
         elif method == 'write_registers':
             address, data = args
             for i, d in enumerate(data):

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -81,7 +81,7 @@ class AsyncioModbusClient(object):
 
     async def write_register(self, address, value, skip_encode=False):
         """Write a modbus register."""
-        return await self._request('write_registers', address, value, skip_encode=skip_encode)
+        return await self._request('write_register', address, value, skip_encode=skip_encode)
 
     async def write_registers(self, address, values, skip_encode=False):
         """Write modbus registers.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='productivity',
-    version='0.4.1',
+    version='0.4.2',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
If using the built-in mock and util functions, `write_registers` is called with only a single value which causes a TypeError

```  
  File "/home/alex/github/controllers/controllers/temperature_box/interfaces.py", line 130, in set
    await self.write_register(
  File "/home/alex/.local/lib/python3.8/site-packages/productivity/util.py", line 84, in write_register
    return await self._request('write_registers', address, value, skip_encode=skip_encode)
  File "/home/alex/github/controllers/controllers/temperature_box/interfaces.py", line 48, in _request
    return await super()._request(*args, **kwargs, unit=1)
  File "/home/alex/.local/lib/python3.8/site-packages/productivity/mock.py", line 53, in _request
    for i, d in enumerate(data):
TypeError: 'int' object is not iterable

```