### PR TITLE
Handle various exceptions caused by the simulator

### DIFF
--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -263,11 +263,13 @@ class ProductivityPLC(AsyncioModbusClient):
                 elif data_type == 'str':
                     chars = self.tags[tag]['length']
                     try:
+                        codec = 'unicode-escape'
                         test_decoder = deepcopy(decoder)
-                        test_decoder.decode_string(chars).decode('ascii')
-                        result[tag] = decoder.decode_string(chars).decode('ascii')
+                        test_decoder.decode_string(chars).decode(codec)
+                        result[tag] = decoder.decode_string(chars).decode(codec).strip('\u0000')
                     except UnicodeDecodeError as e:
-                        result[tag] = decoder.decode_string(chars).decode('ascii', 'ignore')
+                        result[tag] = decoder.decode_string(chars).decode(codec, 'ignore') \
+                            .strip('\u0000')
                         logging.error(f"Decoding register {current} had an error,"
                                       f" which was ignored: {e}")
                     # Handle odd length strings

--- a/productivity/tests/test_driver.py
+++ b/productivity/tests/test_driver.py
@@ -53,8 +53,8 @@ async def test_get(plc_driver):
     expected = {'AV-101': False, 'AV-102': False, 'toggle_AV-101': False,
                 'toggle_AV-102': False, 'FALL-101_OK': False, 'FAL-101_OK': False,
                 'ESD_OK': False, 'FI-101': 0.0, 'FI-102': 0.0, 'Raw Pressure': 0,
-                'GAS-101': '\x00\x00\x00\x00\x00\x00\x00\x00',
-                'GAS-102': '\x00\x00\x00\x00\x00\x00\x00\x00'}
+                'GAS-101': '',
+                'GAS-102': ''}
     assert await plc_driver.get() == expected
 
 
@@ -67,7 +67,7 @@ async def test_roundtrip(plc_driver):
                 'toggle_AV-102': False, 'FALL-101_OK': False, 'FAL-101_OK': False,
                 'ESD_OK': False, 'FI-101': 20.0, 'FI-102': 0.0,
                 'Raw Pressure': 1, 'GAS-101': 'FOO     ',
-                'GAS-102': '\x00\x00\x00\x00\x00\x00\x00\x00'}
+                'GAS-102': ''}
     assert await plc_driver.get() == expected
 
 

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -5,7 +5,10 @@ Copyright (C) 2019 NuMat Technologies
 """
 import asyncio
 
-from pymodbus.client.asynchronous.asyncio import ReconnectingAsyncioModbusTcpClient
+try:
+    from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient
+except ModuleNotFoundError:
+    from pymodbus.client.asynchronous.asyncio import ReconnectingAsyncioModbusTcpClient
 import pymodbus.exceptions
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='productivity',
-    version='0.4.2',
+    version='0.4.3',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #28 (unhandled MODBUS exception codes)
Closes #29 (malformed strings)