### PR TITLE
Python 3.10 version checking

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+    - dependency-name: "pymodbus"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,10 @@ strategy:
   matrix:
     Python37:
       PYTHON_VERSION: '3.7'
+    Python38:
+      PYTHON_VERSION: '3.8'
+    Python39:
+      PYTHON_VERSION: '3.9'
   maxParallel: 3
 
 steps:

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 """Python driver for AutomationDirect Productivity Series PLCs."""
-from platform import python_version
+from sys import version_info
 from setuptools import setup
 
-if python_version() < '3.5':
-    raise ImportError("This module requires Python >=3.5")
+if version_info < (3, 5):
+    raise ImportError("This module requires Python >=3.5 for asyncio support")
+if version_info >= (3, 10):
+    raise ImportError("This module depends on pymodbus, which is incompatible with Python 3.10")
 
 with open('README.md', 'r') as in_file:
     long_description = in_file.read()
 
 setup(
     name='productivity',
-    version='0.4.2',
+    version='0.4.3',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -42,6 +44,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )


### PR DESCRIPTION
Closes #32 

Also dependabot even though it won't do anything because why not?

It's unclear to me whether `pymodbus` actually works on 3.8 or 3.9, but our package does on both, at least when mocked.