### PR TITLE
Fix reading >125 registers

### DIFF
--- a/productivity/util.py
+++ b/productivity/util.py
@@ -66,10 +66,10 @@ class AsyncioModbusClient(object):
         if type not in self._register_types:
             raise ValueError(f"Register type {type} not in {self._register_types}.")
         registers = []
-        while count > 124:
-            r = await self._request(f'read_{type}_registers', address, 124)
+        while count > 125:
+            r = await self._request(f'read_{type}_registers', address, 125)
             registers += r.registers
-            address, count = address + 124, count - 124
+            address, count = address + 125, count - 125
         r = await self._request(f'read_{type}_registers', address, count)
         registers += r.registers
         return registers

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='productivity',
-    version='0.4.4',
+    version='0.5.0',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Neither James or I understand why this works.  But it does (tested on both the new e-gas controller and vacuum ovens).  Reading > 124 registers gives junk data, and this fixes it.

![image](https://user-images.githubusercontent.com/52292902/131407340-727bbddf-48df-455d-950f-cb37c7c910f7.png)
