### PR TITLE
Support pymodbus-3.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 *.egg-info
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Productivity
 
 ##### NOTE: This is in very early stages of development.
 
-Python ≥3.6 driver and command-line tool for [AutomationDirect Productivity Series PLCs](https://www.automationdirect.com/adc/overview/catalog/programmable_controllers/productivity_series_controllers).
+Python ≥3.7 driver and command-line tool for [AutomationDirect Productivity Series PLCs](https://www.automationdirect.com/adc/overview/catalog/programmable_controllers/productivity_series_controllers).
 
 <p align="center">
   <img src="https://www.automationdirect.com/images/overviews/p-series-cpus_400.jpg" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ strategy:
       PYTHON_VERSION: '3.9'
     Python310:
       PYTHON_VERSION: '3.10'
+    Python311:
+      PYTHON_VERSION: '3.11'
   maxParallel: 3
 
 steps:

--- a/productivity/__init__.py
+++ b/productivity/__init__.py
@@ -12,6 +12,7 @@ def command_line():
     import argparse
     import asyncio
     import json
+
     import yaml
 
     parser = argparse.ArgumentParser(description="Control a Productivity PLC "

--- a/productivity/__init__.py
+++ b/productivity/__init__.py
@@ -30,7 +30,7 @@ def command_line(args=None):
             d = await plc.get()
             print(json.dumps(d, indent=4))
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(run())
     loop.close()
 

--- a/productivity/__init__.py
+++ b/productivity/__init__.py
@@ -7,7 +7,7 @@ Copyright (C) 2019 NuMat Technologies
 from productivity.driver import ProductivityPLC
 
 
-def command_line():
+def command_line(args=None):
     """Command-line tool for Productivity PLC communication."""
     import argparse
     import asyncio
@@ -21,7 +21,7 @@ def command_line():
     parser.add_argument('tags', help="The PLC tag database file.")
     parser.add_argument('-s', '--set', type=yaml.safe_load,
                         help="Pass a YAML string with parameters to be set.")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     async def run():
         async with ProductivityPLC(args.address, args.tags) as plc:

--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -2,7 +2,7 @@
 Python driver for AutomationDirect Productivity Series PLCs.
 
 Distributed under the GNU General Public License v2
-Copyright (C) 2019 NuMat Technologies
+Copyright (C) 2022 NuMat Technologies
 """
 import csv
 import logging

--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -10,16 +10,16 @@ import pydoc
 from copy import deepcopy
 from math import ceil
 from string import digits
-from typing import Tuple, Union, Optional, List
+from typing import List, Optional, Tuple, Union
 
-from pymodbus.bit_write_message import WriteSingleCoilResponse
-from pymodbus.bit_write_message import WriteMultipleCoilsResponse
+from pymodbus.bit_write_message import (WriteMultipleCoilsResponse,
+                                        WriteSingleCoilResponse)
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
-from pymodbus.register_write_message import WriteMultipleRegistersResponse
 from pymodbus.pdu import ExceptionResponse
+from pymodbus.register_write_message import WriteMultipleRegistersResponse
 
-from productivity.util import AsyncioModbusClient, DATA_TYPES, TYPE_START
+from productivity.util import DATA_TYPES, TYPE_START, AsyncioModbusClient
 
 
 class ProductivityPLC(AsyncioModbusClient):

--- a/productivity/mock.py
+++ b/productivity/mock.py
@@ -10,11 +10,13 @@ Copyright (C) 2022 NuMat Technologies
 from collections import defaultdict
 from unittest.mock import MagicMock
 
-from pymodbus.bit_read_message import ReadCoilsResponse, ReadDiscreteInputsResponse
-from pymodbus.bit_write_message import WriteSingleCoilResponse, WriteMultipleCoilsResponse
+from pymodbus.bit_read_message import (ReadCoilsResponse,
+                                       ReadDiscreteInputsResponse)
+from pymodbus.bit_write_message import (WriteMultipleCoilsResponse,
+                                        WriteSingleCoilResponse)
 from pymodbus.register_read_message import ReadHoldingRegistersResponse
-from pymodbus.register_write_message import WriteSingleRegisterResponse
-from pymodbus.register_write_message import WriteMultipleRegistersResponse
+from pymodbus.register_write_message import (WriteMultipleRegistersResponse,
+                                             WriteSingleRegisterResponse)
 
 from productivity.driver import ProductivityPLC as realProductivityPLC
 

--- a/productivity/mock.py
+++ b/productivity/mock.py
@@ -4,7 +4,7 @@ Python mock driver for AutomationDirect Productivity Series PLCs.
 Uses local storage instead of remote communications.
 
 Distributed under the GNU General Public License v2
-Copyright (C) 2020 NuMat Technologies
+Copyright (C) 2022 NuMat Technologies
 """
 
 from collections import defaultdict
@@ -26,15 +26,10 @@ class AsyncClientMock(MagicMock):
         """Convert regular mocks into into an async coroutine."""
         return super().__call__(*args, **kwargs)
 
-    def stop(self):
-        """Overide 'stop' as it is the one non-async method in the client."""
-        pass
-
-
 class ProductivityPLC(realProductivityPLC):
     """Mock Productivity driver using local storage instead of remote communication."""
 
-    @patch('pymodbus.client.asynchronous.async_io.ReconnectingAsyncioModbusTcpClient')
+    @patch('pymodbus.client.AsyncModbusTcpClient')
     def __init__(self, address, tag_filepath, timeout=1, *args, **kwargs):
         super().__init__(address, tag_filepath, timeout)
         self.client = AsyncClientMock()

--- a/productivity/tests/test_driver.py
+++ b/productivity/tests/test_driver.py
@@ -1,6 +1,9 @@
 """Test the driver correctly parses a tags file and responds with correct data."""
+from unittest import mock
+
 import pytest
 
+from productivity import command_line
 from productivity.mock import ProductivityPLC
 
 
@@ -15,6 +18,17 @@ def test_init():
     with pytest.raises(TypeError, match='unsupported data type'):
         ProductivityPLC('fake ip', 'tests/bad_tags.csv')
 
+
+@mock.patch('productivity.ProductivityPLC', ProductivityPLC)
+def test_driver_cli_tags(capsys):
+    """Confirm the commandline interface works with a tags file."""
+    command_line(['fakeip', 'tests/plc_tags.csv'])
+    captured = capsys.readouterr()
+    assert 'AV-101' in captured.out
+    assert 'GAS-101' in captured.out
+    assert 'TI-101' in captured.out
+    with pytest.raises(SystemExit):
+        command_line(['fakeip', 'tags', 'bogus'])
 
 def test_get_tags(plc_driver):
     """Confirm the driver returns the tags defined in the tags file."""

--- a/productivity/tests/test_driver.py
+++ b/productivity/tests/test_driver.py
@@ -30,6 +30,7 @@ def test_driver_cli_tags(capsys):
     with pytest.raises(SystemExit):
         command_line(['fakeip', 'tags', 'bogus'])
 
+
 def test_get_tags(plc_driver):
     """Confirm the driver returns the tags defined in the tags file."""
     expected = {

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -65,7 +65,7 @@ class AsyncioModbusClient(object):
 
     async def __aexit__(self, *args):
         """Provide exit to the context manager."""
-        await self.close()
+        await self._close()
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
@@ -169,7 +169,7 @@ class AsyncioModbusClient(object):
             except pymodbus.exceptions.ConnectionException as e:
                 raise ConnectionError(e)
 
-    async def close(self):
+    async def _close(self):
         """Close the TCP connection."""
         try:
             await self.client.close()  # 3.x

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -56,12 +56,11 @@ class AsyncioModbusClient(object):
         except NameError:
             self.client = ReconnectingAsyncioModbusTcpClient()  # 2.4.x - 2.5.x
         self.lock = asyncio.Lock()
-        asyncio.create_task(self._connect())
+        self.connectTask = asyncio.create_task(self._connect())
         self.open = False
 
     async def __aenter__(self):
         """Asynchronously connect with the context manager."""
-        await self._connect()
         return self
 
     async def __aexit__(self, *args):
@@ -152,6 +151,7 @@ class AsyncioModbusClient(object):
         exist, other logic will have to be added to either prevent or manage
         race conditions.
         """
+        await self.connectTask
         async with self.lock:
             if not self.client.connected or not self.open:
                 raise TimeoutError("Not connected to PLC.")

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 from sys import version_info
 from setuptools import setup
 
-if version_info < (3, 6):
-    raise ImportError("This module requires Python >=3.6 for asyncio support")
 if version_info < (3, 7):
     raise ImportError("This module requires Python >=3.7.  Use 0.6.0 for Python3.6")
 
@@ -12,7 +10,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='productivity',
-    version='0.7.1',
+    version='0.8.0',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -24,7 +22,10 @@ setup(
         'console_scripts': [('productivity = productivity:command_line')]
     },
     install_requires=[
-        'pymodbus>=2.4.0,<3',
+        'pymodbus>=2.4.0,<3; python_version == "3.7"',
+        'pymodbus[serial]>=2.4.0; python_version == "3.8"',
+        'pymodbus[serial]>=2.4.0; python_version == "3.9"',
+        'pymodbus[serial]>=3.0.0; python_version >= "3.10"',
         'PyYAML',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ setup(
     },
     install_requires=[
         'pymodbus>=2.4.0,<3; python_version == "3.7"',
-        'pymodbus[serial]>=2.4.0; python_version == "3.8"',
-        'pymodbus[serial]>=2.4.0; python_version == "3.9"',
-        'pymodbus[serial]>=3.0.0; python_version >= "3.10"',
+        'pymodbus>=2.4.0; python_version == "3.8"',
+        'pymodbus>=2.4.0; python_version == "3.9"',
+        'pymodbus>=3.0.2; python_version >= "3.10"',
         'PyYAML',
     ],
     extras_require={


### PR DESCRIPTION
Pymodbus `3.0.0` fixes a lot of DeprecationWarnings, which is great.  It also simplifies the MODBUS client code, so we need to match those refactors.

Notably, things aren't pretty if an initial `connect()` fails:
- there's not a timeout on the raw [`create_connect()`](https://github.com/riptideio/pymodbus/blob/428d3f347bef0a330a56a43444dd02f9230b7f71/pymodbus/client/tcp.py#L85) => I'm considering opening a PR
- it will only attempt a reconnect 3x => I think we should address this in our controllers repo and not this driver.

I also moved to `asyncio.Lock`.  My implementation isn't perfect, but it doesn't appear to cause regressions, and appears to prevent a race condition with `self.waiting` where a `_request` could fire before the connection has been established.  There has also been a subtle but where `_connect()` was called twice when using an async context manager.

I've tested:
- [x] the CLI and a real PLC => success
- [x] CLI and a real PLC with network disconnected  => `TimeoutError("Not connected to PLC.")`
- [x] CLI and bad PLC address. => `OSError: Could not connect to <IP>`
- [x] A controller (i.e. initializing the `ProductivityPLC` class with a mocked PLC => reads successfully
- [x] A controller with a real PLC => reads successfully
- [x] A controller with a bad PLC address => throws Exceptions as expected
- [x] A controller with a real PLC and a _network_ disconnect => Catches most, but not all exceptions/timeouts.  `util.loop()` sometimes has to kill with `asyncio.Timeout`.  This is functionally fine, but makes for less-useful error messages.
- [x] A controller with a real PLC and a _PLC_ disconnect => same as above