### PR TITLE
Drop Python3.6 and support 3.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,14 +10,14 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    Python36:
-      PYTHON_VERSION: '3.6'
     Python37:
       PYTHON_VERSION: '3.7'
     Python38:
       PYTHON_VERSION: '3.8'
     Python39:
       PYTHON_VERSION: '3.9'
+    Python310:
+      PYTHON_VERSION: '3.10'
   maxParallel: 3
 
 steps:

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@ from setuptools import setup
 
 if version_info < (3, 6):
     raise ImportError("This module requires Python >=3.6 for asyncio support")
-if version_info >= (3, 10):
-    raise ImportError("This module depends on pymodbus, which is incompatible with Python 3.10")
+if version_info < (3, 7):
+    raise ImportError("This module requires Python >=3.7.  Use 0.6.0 for Python3.6")
 
 with open('README.md', 'r') as in_file:
     long_description = in_file.read()
 
 setup(
     name='productivity',
-    version='0.6.0',
+    version='0.7.0',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -41,10 +41,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )


### PR DESCRIPTION
Apparently pymodbus2.x [remains compatible](https://github.com/riptideio/pymodbus/issues/560) with Python3.10 and we don't have to wait for 3.x


