### PR TITLE
Enable flake8 and mypy in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
   displayName: 'Lint Code'
 
 - script: |
-    mypy clickplc
+    mypy productivity
   displayName: 'Check types with mypy'
 
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,14 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
+    flake8 productivity
+  displayName: 'Lint Code'
+
+- script: |
+    mypy clickplc
+  displayName: 'Check types with mypy'
+
+- script: |
     cd productivity
     pytest --junitxml=../reports/test-coverage.xml  --cov=. --cov-report=xml
   env:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     ],
     extras_require={
         'test': [
+            'mypy==1.0.1',
             'pytest',
             'pytest-cov',
             'pytest-asyncio',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             'pytest',
             'pytest-cov',
             'pytest-asyncio',
+            'types-PyYAML'
         ],
     },
     license='GPLv2',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
     ],
     extras_require={
         'test': [
+            'flake8>=3,<7',
+            'flake8-docstrings==1.*',
             'mypy==1.0.1',
             'pytest',
             'pytest-cov',


### PR DESCRIPTION
`flake8` wasn't enabled, for some reason.  Also, add `mypy` but ignore missing imports for now since pymodbus hasn't released a typed version yet.
