### PR TITLE
Drop Python3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,21 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         pymodbus-version: ["2.5.3", "3.0.2", "3.1.3", "3.2.2", "3.3.1"]
         exclude:
         - python-version: "3.10"
           pymodbus-version: "2.5.3"
         - python-version: "3.11"
           pymodbus-version: "2.5.3"
-        - python-version: "3.7"
-          pymodbus-version: "3.0.2"
-        - python-version: "3.7"
-          pymodbus-version: "3.1.3"
-        - python-version: "3.7"
-          pymodbus-version: "3.2.2"
-        - python-version: "3.7"
-          pymodbus-version: "3.3.1"
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Productivity
 
 ##### NOTE: This is in very early stages of development.
 
-Python ≥3.7 driver and command-line tool for [AutomationDirect Productivity Series PLCs](https://www.automationdirect.com/adc/overview/catalog/programmable_controllers/productivity_series_controllers).
+Python ≥3.8 driver and command-line tool for [AutomationDirect Productivity Series PLCs](https://www.automationdirect.com/adc/overview/catalog/programmable_controllers/productivity_series_controllers).
 
 <p align="center">
   <img src="https://www.automationdirect.com/images/overviews/p-series-cpus_400.jpg" />

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'console_scripts': [('productivity = productivity:command_line')]
     },
     install_requires=[
-        'pymodbus>=2.4.0,<3; python_version == "3.7"',
         'pymodbus>=2.4.0; python_version == "3.8"',
         'pymodbus>=2.4.0; python_version == "3.9"',
         'pymodbus>=3.0.2,<3.4.0; python_version >= "3.10"',
@@ -48,7 +47,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
[EOL as of 2023-06-27](https://devguide.python.org/versions/)
