### PR TITLE
Remove lock from `_connect`

### DIFF
--- a/productivity/util.py
+++ b/productivity/util.py
@@ -5,15 +5,17 @@ Copyright (C) 2022 NuMat Technologies
 """
 import asyncio
 import logging
-logger = logging.getLogger('controller')
 
 try:
     import pymodbus
+
     # pymodbus.logging.pymodbus_apply_logging_config()
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
     from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient  # type: ignore
 import pymodbus.exceptions
+
+logger = logging.getLogger('controller')
 
 TYPE_START = {
     'discrete_output': 0,

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -51,7 +51,7 @@ class AsyncioModbusClient:
 
     def __init__(self, address, timeout=1):
         """Set up communication parameters."""
-        logging.debug("AsyncioModbusClient.init debug test")
+        logging.info("AsyncioModbusClient.init info test")
         logging.error("AsyncioModbusClient.init error test")
         self.ip = address
         self.timeout = timeout
@@ -77,11 +77,11 @@ class AsyncioModbusClient:
         self.pymodbus30plus = int(pymodbus.__version__[0]) == 3
         self.pymodbus32plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 2
         self.pymodbus33plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 3
-        logging.debug(f"pymodbus flags {self.pymodbus30plus} {self.pymodbus32plus} {self.pymodbus33plus}")
+        logging.info(f"pymodbus flags {self.pymodbus30plus} {self.pymodbus32plus} {self.pymodbus33plus}")
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
-        logging.debug("AsyncioModbusClient._connect")
+        logging.info("AsyncioModbusClient._connect")
         try:
             if self.pymodbus30plus:
                 await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
@@ -171,7 +171,7 @@ class AsyncioModbusClient:
             return await future(*args, **kwargs)
 
     async def _close(self) -> None:
-        logging.debug("productivity.util _close")
+        logging.info("productivity.util _close")
         """Close the TCP connection."""
         if self.pymodbus33plus:
             self.client.close()  # 3.3.x

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -9,7 +9,7 @@ import logging
 try:
     import pymodbus
     # pymodbus.logging.Log.apply_logging_config(logging.INFO, None)
-    pymodbus.logging.pymodbus_apply_logging_config("INFO")
+    pymodbus.logging.pymodbus_apply_logging_config()
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
     from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient  # type: ignore

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -5,7 +5,7 @@ Copyright (C) 2022 NuMat Technologies
 """
 import asyncio
 import logging
-logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger('controller')
 
 try:
     import pymodbus
@@ -51,8 +51,8 @@ class AsyncioModbusClient:
 
     def __init__(self, address, timeout=1):
         """Set up communication parameters."""
-        logging.info("AsyncioModbusClient.init info test")
-        logging.error("AsyncioModbusClient.init error test")
+        logger.info("AsyncioModbusClient.init info test")
+        logger.error("AsyncioModbusClient.init error test")
         self.ip = address
         self.timeout = timeout
         self._register_types = ['holding', 'input']
@@ -77,11 +77,11 @@ class AsyncioModbusClient:
         self.pymodbus30plus = int(pymodbus.__version__[0]) == 3
         self.pymodbus32plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 2
         self.pymodbus33plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 3
-        logging.info(f"pymodbus flags {self.pymodbus30plus} {self.pymodbus32plus} {self.pymodbus33plus}")
+        logger.info(f"pymodbus flags {self.pymodbus30plus} {self.pymodbus32plus} {self.pymodbus33plus}")
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
-        logging.info("AsyncioModbusClient._connect")
+        logger.info("AsyncioModbusClient._connect")
         try:
             if self.pymodbus30plus:
                 await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
@@ -171,7 +171,7 @@ class AsyncioModbusClient:
             return await future(*args, **kwargs)
 
     async def _close(self) -> None:
-        logging.info("productivity.util _close")
+        logger.info("productivity.util _close")
         """Close the TCP connection."""
         if self.pymodbus33plus:
             self.client.close()  # 3.3.x

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -156,14 +156,11 @@ class AsyncioModbusClient:
         """
         await self.connectTask # ensures the _connect Task triggered from _init is copmplete
         async with self.lock:
-            try:
-                if self.pymodbus32plus:
-                    future = getattr(self.client, method)
-                else:
-                    future = getattr(self.client.protocol, method)  # type: ignore
-                return await future(*args, **kwargs)
-            except (asyncio.TimeoutError, pymodbus.exceptions.ConnectionException):
-                raise TimeoutError("Not connected to PLC.")
+            if self.pymodbus32plus:
+                future = getattr(self.client, method)
+            else:
+                future = getattr(self.client.protocol, method)  # type: ignore
+            return await future(*args, **kwargs)
 
     async def _close(self) -> None:
         """Close the TCP connection."""

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -8,8 +8,8 @@ import logging
 
 try:
     import pymodbus
-    pymodbus.logging.Log.apply_logging_config(logging.INFO, None)
-    # pymodbus.logging.pymodbus_apply_logging_config()
+    # pymodbus.logging.Log.apply_logging_config(logging.INFO, None)
+    pymodbus.logging.pymodbus_apply_logging_config("INFO")
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
     from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient  # type: ignore

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -74,14 +74,13 @@ class AsyncioModbusClient:
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
-        async with self.lock:
-            try:
-                if self.pymodbus30plus:
-                    await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
-                else:  # 2.4.x - 2.5.x
-                    await self.client.start(self.ip)  # type: ignore
-            except Exception:
-                raise OSError(f"Could not connect to '{self.ip}'.")
+        try:
+            if self.pymodbus30plus:
+                await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
+            else:  # 2.4.x - 2.5.x
+                await self.client.start(self.ip)  # type: ignore
+        except Exception:
+            raise OSError(f"Could not connect to '{self.ip}'.")
 
     async def read_coils(self, address, count):
         """Read modbus output coils (0 address prefix)."""
@@ -155,7 +154,7 @@ class AsyncioModbusClient:
         exist, other logic will have to be added to either prevent or manage
         race conditions.
         """
-        await self.connectTask
+        await self.connectTask # ensures the _connect Task triggered from _init is copmplete
         async with self.lock:
             try:
                 if self.pymodbus32plus:

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -8,7 +8,7 @@ import logging
 
 try:
     import pymodbus
-
+    pymodbus.logging.Log.apply_logging_config(logging.INFO, None)
     # pymodbus.logging.pymodbus_apply_logging_config()
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -4,18 +4,12 @@ Distributed under the GNU General Public License v2
 Copyright (C) 2022 NuMat Technologies
 """
 import asyncio
-import logging
 
 try:
-    import pymodbus
-    # pymodbus.logging.Log.apply_logging_config(logging.INFO, None)
-    pymodbus.logging.pymodbus_apply_logging_config()
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
     from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient  # type: ignore
 import pymodbus.exceptions
-
-logger = logging.getLogger('controller')
 
 TYPE_START = {
     'discrete_output': 0,
@@ -53,8 +47,6 @@ class AsyncioModbusClient:
 
     def __init__(self, address, timeout=1):
         """Set up communication parameters."""
-        logger.info("AsyncioModbusClient.init info test")
-        logger.error("AsyncioModbusClient.init error test")
         self.ip = address
         self.timeout = timeout
         self._register_types = ['holding', 'input']
@@ -79,11 +71,9 @@ class AsyncioModbusClient:
         self.pymodbus30plus = int(pymodbus.__version__[0]) == 3
         self.pymodbus32plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 2
         self.pymodbus33plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 3
-        logger.info(f"pymodbus flags {self.pymodbus30plus} {self.pymodbus32plus} {self.pymodbus33plus}")
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
-        logger.info("AsyncioModbusClient._connect")
         try:
             if self.pymodbus30plus:
                 await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
@@ -173,7 +163,6 @@ class AsyncioModbusClient:
             return await future(*args, **kwargs)
 
     async def _close(self) -> None:
-        logger.info("productivity.util _close")
         """Close the TCP connection."""
         if self.pymodbus33plus:
             self.client.close()  # 3.3.x

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -9,7 +9,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 try:
     import pymodbus
-    pymodbus.logging.pymodbus_apply_logging_config()
+    # pymodbus.logging.pymodbus_apply_logging_config()
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
     from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient  # type: ignore

--- a/productivity/util.py
+++ b/productivity/util.py
@@ -4,8 +4,12 @@ Distributed under the GNU General Public License v2
 Copyright (C) 2022 NuMat Technologies
 """
 import asyncio
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
 try:
+    import pymodbus
+    pymodbus.logging.pymodbus_apply_logging_config()
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
     from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient  # type: ignore
@@ -47,6 +51,8 @@ class AsyncioModbusClient:
 
     def __init__(self, address, timeout=1):
         """Set up communication parameters."""
+        logging.debug("AsyncioModbusClient.init debug test")
+        logging.error("AsyncioModbusClient.init error test")
         self.ip = address
         self.timeout = timeout
         self._register_types = ['holding', 'input']
@@ -71,9 +77,11 @@ class AsyncioModbusClient:
         self.pymodbus30plus = int(pymodbus.__version__[0]) == 3
         self.pymodbus32plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 2
         self.pymodbus33plus = self.pymodbus30plus and int(pymodbus.__version__[2]) >= 3
+        logging.debug(f"pymodbus flags {self.pymodbus30plus} {self.pymodbus32plus} {self.pymodbus33plus}")
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
+        logging.debug("AsyncioModbusClient._connect")
         try:
             if self.pymodbus30plus:
                 await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
@@ -163,6 +171,7 @@ class AsyncioModbusClient:
             return await future(*args, **kwargs)
 
     async def _close(self) -> None:
+        logging.debug("productivity.util _close")
         """Close the TCP connection."""
         if self.pymodbus33plus:
             self.client.close()  # 3.3.x

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as in_file:
 
 setup(
     name='productivity',
-    version='0.10.0',
+    version='0.10.1',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Lock on `_connect` seems to be redundant, since `_request` already awaits the `connectTask`.
- Bubble up `TimeOut` and `Connection` exceptions as different exceptions, so they can dealt with the container separately (ignore, or remake a connection).