### PR TITLE
Remove lock from _connect

### DIFF
--- a/productivity/util.py
+++ b/productivity/util.py
@@ -75,14 +75,13 @@ class AsyncioModbusClient:
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
-        async with self.lock:
-            try:
-                if self.pymodbus30plus:
-                    await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
-                else:  # 2.4.x - 2.5.x
-                    await self.client.start(self.ip)  # type: ignore
-            except Exception:
-                raise OSError(f"Could not connect to '{self.ip}'.")
+        try:
+            if self.pymodbus30plus:
+                await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
+            else:  # 2.4.x - 2.5.x
+                await self.client.start(self.ip)  # type: ignore
+        except Exception:
+            raise OSError(f"Could not connect to '{self.ip}'.")
 
     async def read_coils(self, address, count):
         """Read modbus output coils (0 address prefix)."""
@@ -156,7 +155,7 @@ class AsyncioModbusClient:
         exist, other logic will have to be added to either prevent or manage
         race conditions.
         """
-        await self.connectTask
+        await self.connectTask  # ensure the _connect Task triggered from _init is complete
         async with self.lock:
             try:
                 if self.pymodbus32plus:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as in_file:
 
 setup(
     name='productivity',
-    version='0.10.1',
+    version='0.11.0',
     description="Python driver for AutomationDirect Productivity Series PLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
See https://github.com/numat/productivity/pull/76

Lock on `_connect` seems to be redundant, since `_request` already awaits the `connectTask`.
